### PR TITLE
used reqURL in the oauthfactory but defined as requestURL

### DIFF
--- a/man/registerTwitterOAuth.Rd
+++ b/man/registerTwitterOAuth.Rd
@@ -30,11 +30,11 @@ registerTwitterOAuth(oauth)
     \dontrun{
        ## A real example, but using a fictitious consumerkey and consumer
        ## secret - you'll need to supply your own
-       requestURL <- "https://api.twitter.com/oauth/request_token"
+       reqURL <- "https://api.twitter.com/oauth/request_token"
        accessURL = "http://api.twitter.com/oauth/access_token"
        authURL = "http://api.twitter.com/oauth/authorize"
-       consumerKey = "FAKEDATA"
-       consumerSecret = "FAKEDATA"
+       consumerKey = "12345pqrst6789ABCD"
+       consumerSecret = "abcd1234EFGH5678ijkl0987MNOP6543qrst21"
        twitCred <- OAuthFactory$new(consumerKey=consumerKey,
                                     consumerSecret=consumerSecret,
                                     requestURL=reqURL,


### PR DESCRIPTION
But -- why not just paste the text directly into the factory?  e.g.

```
twitCred <- OAuthfactory$new(
consumerKey="12345pqrst6789ABCD",
requestURL="https://api.twitter.com/oauth/request_token"
 .......etc
)
```

This OO structure isn't necessary for the tutorial.
