### PR TITLE
same tweets are fetched or inifinite loop occurs in doRppAPICall

### DIFF
--- a/R/comm.R
+++ b/R/comm.R
@@ -160,10 +160,18 @@ doRppAPICall = function(cmd, num, params, ...) {
   while (curDiff > 0) {
     fromJSON <- twInterfaceObj$doAPICall(cmd, params, 'GET', ...)
     newList <- fromJSON$statuses
+    if (length(newList) == 0) {
+      break;
+    }
     jsonList <- c(jsonList, newList)
     curDiff <- num - length(jsonList)
-    if ((curDiff > 0) && ("search_metadata" %in% names(fromJSON)) && ("max_id_str" %in% names(fromJSON[["search_metadata"]]))) {
-      params[["max_id"]] = fromJSON[["search_metadata"]][["max_id_str"]]
+    if ((curDiff > 0) && ("search_metadata" %in% names(fromJSON)) && ("since_id_str" %in% names(fromJSON[["search_metadata"]]))) {
+      ## since_id_str will be "0" if there are no data anymore,
+      ## and search/tweets API v1.1 seems to ignore max_id if it is less than 2
+      if (as.numeric(fromJSON[["search_metadata"]][["since_id_str"]]) < 2) {
+        break;
+      }
+      params[["max_id"]] = fromJSON[["search_metadata"]][["since_id_str"]]
     }
   }
   


### PR DESCRIPTION
doRppAPICall fetches same tweets if the number of tweets is less than 'num' argument,
because max_id_str is used as max_id parameter.
max_id_str should be replaced with since_id_str.

In addition, infinite loop occurs if length(newList) is 0, e.g. a future date is specified as 'since' argument.
The while loop should be terminated if length(newList) is 0.
