### PR TITLE
allow character as showStatus argument

### DIFF
--- a/R/statuses.R
+++ b/R/statuses.R
@@ -134,8 +134,8 @@ deleteStatus <- function(status, ...) {
 }
 
 showStatus <- function(id, ...) {
-  if (!is.numeric(id))
-    stop("id argument must be numeric")
+  if (!is.numeric(id) && !is.character(id))
+    stop("id argument must be numeric or character")
   buildStatus(twInterfaceObj$doAPICall(paste('statuses', 'show', id, sep='/'), ...))
 }
 


### PR DESCRIPTION
This pull request is related with #5 and just allows character as showStatus argument.
I think showStatus should throw an exception or show a warning message when id is numeric, but I shouldn't decide it.
