### PR TITLE
fix: deleteStatus doesn't work

### DIFF
--- a/R/statuses.R
+++ b/R/statuses.R
@@ -128,8 +128,17 @@ deleteStatus <- function(status, ...) {
     stop("deleteStatus requires OAuth authentication")
   if (!inherits(status, 'status'))
     stop("status argument must be of class status")
-  twInterfaceObj$doAPICall('statuses/destroy', params=list(id=status$getId()), method='POST', ...)
-  TRUE
+  json <- twInterfaceObj$doAPICall(paste('statuses/destroy',
+                                         status$getId(), sep='/'),
+                                   method='POST', ...)
+  if (is.null(json$errors)) {
+    TRUE
+  } else {
+    for (error in json$errors) {
+      cat(error$message, error$code, fill = TRUE)
+    }
+    FALSE
+  }
 }
 
 showStatus <- function(id, ...) {


### PR DESCRIPTION
The endpoint URL of statuses/destroy/:id API is like "https://api.twitter.com/1.1/statuses/destroy/240854986559455234.json".
cf. https://dev.twitter.com/docs/api/1.1/post/statuses/destroy/%3Aid

deleteStatus will pass no parameters by this change, so this change depends on https://github.com/geoffjentry/ROAuth/pull/6.
