### PR TITLE
excludeReplies parameter in userTimeline 

### DIFF
--- a/R/statuses.R
+++ b/R/statuses.R
@@ -199,13 +199,14 @@ favorites = function(user, n=20, max_id=NULL, since_id=NULL, ...) {
   return(statusBase(cmd, params, n, 200, ...))
 }
 
-userTimeline = function(user, n=20, maxID=NULL, sinceID=NULL, includeRts=FALSE, ...) {
+userTimeline = function(user, n=20, maxID=NULL, sinceID=NULL, includeRts=FALSE, excludeReplies=FALSE, ...) {
   uParams <- parseUsers(user)
   cmd <- 'statuses/user_timeline'
   params <- buildCommonArgs(max_id=maxID, since_id=sinceID)
   params[['user_id']] <- uParams[['user_id']]
   params[['screen_name']] <- uParams[['screen_name']]
   params[["include_rts"]] <- ifelse(includeRts == TRUE, "true", "false")
+  params[["exclude_replies"]] <- ifelse(excludeReplies == TRUE, "true", "false")
   return(statusBase(cmd, params, n, 3200, ...))
 }
 

--- a/man/timelines.Rd
+++ b/man/timelines.Rd
@@ -9,7 +9,7 @@
   the Twitter universe
 }
 \usage{
-userTimeline(user, n=20, maxID=NULL, sinceID=NULL, includeRts=FALSE, ...)
+userTimeline(user, n=20, maxID=NULL, sinceID=NULL, includeRts=FALSE, excludeReplies=FALSE, ...)
 homeTimeline(n=25, maxID=NULL, sinceID=NULL, ...)
 mentions(n=25, maxID=NULL, sinceID=NULL, ...)
 retweetsOfMe(n=25, maxID=NULL, sinceID=NULL, ...)
@@ -22,6 +22,7 @@ retweetsOfMe(n=25, maxID=NULL, sinceID=NULL, ...)
   \item{sinceID}{Minimum (not inclusive) ID to search for}
   \item{includeRts}{If \code{FALSE} any native retweets (not old style RT retweets)
   		       will be stripped from the results} 
+  \item{excludeReplies}{if \code{TRUE} any replies are stripped from the results}
   \item{...}{Optional arguments to be passed to \code{\link{getURL}}}
 }
 \value{


### PR DESCRIPTION
Added parameter to userTimeline so that exclude_replies can be set on an API call to twitter. Updated documentation to reflect change.

Raised in https://github.com/geoffjentry/twitteR/issues/36 - Decided to stick with how twitter names the parameter. 
