### PR TITLE
Optional 140 character limit bypass (t.co URLs)

### DIFF
--- a/R/statuses.R
+++ b/R/statuses.R
@@ -154,7 +154,7 @@ setMethod("show", signature="status", function(object) {
 })
 
 updateStatus <- function(text, lat=NULL, long=NULL, placeID=NULL,
-                         displayCoords=NULL, inReplyTo=NULL, mediaPath=NULL, bypassCharLimit=F ...) {
+                         displayCoords=NULL, inReplyTo=NULL, mediaPath=NULL, bypassCharLimit=F, ...) {
   if (!has_oauth_token())
     stop("updateStatus requires OAuth authentication")
 

--- a/R/statuses.R
+++ b/R/statuses.R
@@ -154,11 +154,11 @@ setMethod("show", signature="status", function(object) {
 })
 
 updateStatus <- function(text, lat=NULL, long=NULL, placeID=NULL,
-                         displayCoords=NULL, inReplyTo=NULL, mediaPath=NULL, ...) {
+                         displayCoords=NULL, inReplyTo=NULL, mediaPath=NULL, bypassCharLimit=F ...) {
   if (!has_oauth_token())
     stop("updateStatus requires OAuth authentication")
 
-  if (nchar(text) > 140)
+  if (nchar(text) > 140 && !bypassCharLimit)
     stop("Status can not be more than 140 characters")
 
   params = buildCommonArgs(lat=lat, long=long, place_id=placeID,

--- a/R/statuses.R
+++ b/R/statuses.R
@@ -154,7 +154,7 @@ setMethod("show", signature="status", function(object) {
 })
 
 updateStatus <- function(text, lat=NULL, long=NULL, placeID=NULL,
-                         displayCoords=NULL, inReplyTo=NULL, mediaPath=NULL, bypassCharLimit=F, ...) {
+                         displayCoords=NULL, inReplyTo=NULL, mediaPath=NULL, bypassCharLimit=FALSE, ...) {
   if (!has_oauth_token())
     stop("updateStatus requires OAuth authentication")
 


### PR DESCRIPTION
t.co URL shortening shortens links to 22 or 23 characters, meaning the input string can effectively exceed 140 characters. See issue #80