### PR TITLE
Low-level OAuth option

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -9,6 +9,7 @@ exportMethods(as.data.frame, screenName, show, favorited, replyToSN,
 export("search_twitter_and_store")
 export("get_latest_tweet_id")
 export("setup_twitter_oauth")
+export("use_oauth_token")
 export("register_db_backend")
 export("register_sqlite_backend")
 export("register_mysql_backend")

--- a/R/followers.R
+++ b/R/followers.R
@@ -7,12 +7,11 @@ friends <- function(user_id, n=NULL, ...) {
 }
 
 ffBase <- function(type, user_id, n=NULL, ...) {
-  if (can_access_other_account(user_id)) {
-    params <- parseUsers(user_id)
-    doCursorAPICall(paste(type, 'ids', sep='/'), 'ids', num=n, params=params, method='GET', ...)
-  } else {
-    warning("Can not lookup relationships for user id ", user_id)
+  if (!can_access_other_account(user_id)) {
+    warning("Cannot lookup relationships for user id ", user_id, ", query may fail!")
   }
+  params <- parseUsers(user_id)
+  doCursorAPICall(paste(type, 'ids', sep='/'), 'ids', num=n, params=params, method='GET', ...)
 }
 
 friendships = function(screen_names=character(), user_ids=character(), ...) {

--- a/R/oauth.R
+++ b/R/oauth.R
@@ -45,6 +45,10 @@ setup_twitter_oauth = function(consumer_key, consumer_secret, access_token=NULL,
   check_twitter_oauth()
 }
 
+use_oauth_token = function(twitter_token) {
+  assign("oauth_token", twitter_token, envir=oauth_cache)
+}
+
 has_oauth_token = function() {
   exists("oauth_token", envir=oauth_cache)
 }

--- a/man/use_oauth_token.Rd
+++ b/man/use_oauth_token.Rd
@@ -36,6 +36,8 @@ Anand Patil
       credentials = list(access_token = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\%2FAAAAAAAAAAAAAAAAAAAA\%3DAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
       cache = FALSE
     )
+
+    use_oauth_token(token)
   }
 }
 \keyword{interface}

--- a/man/use_oauth_token.Rd
+++ b/man/use_oauth_token.Rd
@@ -1,0 +1,41 @@
+\name{use_oauth_token}
+\alias{use_oauth_token}
+\title{
+Sets up the OAuth credentials for a twitteR session from an existing Token object
+}
+\description{
+This function uses an existing httr OAuth Token in the Twitter session
+}
+\usage{
+use_oauth_token(twitter_token)
+}
+\arguments{
+  \item{twitter_token}{An httr Token object}
+}
+\details{
+  This function is an escape hatch for nonstandard OAuth scenarios. Use setup_twitter_token
+  unless it doesn't work for your use case.
+}
+\value{
+  This is called for its side effect
+}
+\author{
+Anand Patil
+}
+\seealso{
+\code{\link{use_twitter_token}}, \code{\link{Token}}
+}
+\examples{
+ \dontrun{
+    library(httr)
+    library(twitteR)
+    token <- Token2.0$new(
+      params = list(as_header=TRUE),
+      app = oauth_app("fun.with.twitter", "no.key", "no.secret"),
+      endpoint = oauth_endpoints("twitter"),
+      credentials = list(access_token = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%2FAAAAAAAAAAAAAAAAAAAA%3DAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+      cache = FALSE
+    )
+  }
+}
+\keyword{interface}

--- a/man/use_oauth_token.Rd
+++ b/man/use_oauth_token.Rd
@@ -33,7 +33,7 @@ Anand Patil
       params = list(as_header=TRUE),
       app = oauth_app("fun.with.twitter", "no.key", "no.secret"),
       endpoint = oauth_endpoints("twitter"),
-      credentials = list(access_token = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA%2FAAAAAAAAAAAAAAAAAAAA%3DAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+      credentials = list(access_token = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\%2FAAAAAAAAAAAAAAAAAAAA\%3DAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
       cache = FALSE
     )
   }


### PR DESCRIPTION
Hi @geoffjentry,

Thanks for twitteR! This PR adds function `use_oauth_token`, which allows us to create a Token object directly and hand it to twitteR.

The reason I need this is that I want to grant twitteR [application-only](https://dev.twitter.com/oauth/application-only) authentication, but there are also several [other](https://dev.twitter.com/oauth/overview) cases that the current twitteR OAuth scheme doesn't cover.