### PR TITLE
Add base64enc to dependencies list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.1.9
 Author: Jeff Gentry <geoffjentry@gmail.com>
 Maintainer: Jeff Gentry <geoffjentry@gmail.com>
 Depends: R (>= 2.12.0)
-Imports: methods, bit64, rjson, DBI (>= 0.3.1), httr (>= 1.0.0)
+Imports: methods, bit64, rjson, DBI (>= 0.3.1), httr (>= 1.0.0), base64enc
 Suggests: RSQLite, RMySQL
 License: Artistic-2.0
 LazyData: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.1.9
 Author: Jeff Gentry <geoffjentry@gmail.com>
 Maintainer: Jeff Gentry <geoffjentry@gmail.com>
 Depends: R (>= 2.12.0)
-Imports: methods, bit64, rjson, DBI (>= 0.3.1), httr (>= 1.0.0), base64enc
+Imports: methods, bit64, rjson, DBI (>= 0.3.1), httr (>= 1.0.0), base64enc, httpuv
 Suggests: RSQLite, RMySQL
 License: Artistic-2.0
 LazyData: yes


### PR DESCRIPTION
Got the following error when trying to use this for the first time:

> setup_twitter_oauth(...)
[1] "Using browser based authentication"
Use a local file to cache OAuth access credentials between R sessions?
1: Yes
2: No

Selection: 1
Adding .httr-oauth to .gitignore
Error in loadNamespace(name) : there is no package called ‘base64enc’
