### PR TITLE
Fix problem with `since` and `until` argument

### DIFF
--- a/R/search.R
+++ b/R/search.R
@@ -54,16 +54,16 @@ searchTwitter <- function(searchString, n=25, lang=NULL,
   jsonList <- doRppAPICall("search/tweets", n, params=params, retryOnRateLimit=retryOnRateLimit, ...)
   statuses = import_statuses(jsonList)
 
-  datetimes = sapply(statuses, function(x) x$getCreated())
+  datetimes = sapply(statuses, function(x) as.Date(x$getCreated()))
   if (is.null(since)) {
     since_statuses = seq_along(statuses)
   } else {
-    since_statuses = which(datetimes >= as.numeric(as.POSIXct(since, tz="UTC")))
+    since_statuses = which(datetimes >= as.numeric(as.Date(since)))
   }
   if (is.null(until)) {
     until_statuses = seq_along(statuses)
   } else {
-    until_statuses = which(datetimes <= as.numeric(as.POSIXct(until, tz="UTC")))
+    until_statuses = which(datetimes <= as.numeric(as.Date(until)))
   }
   good_statuses = intersect(since_statuses, until_statuses)
   return(statuses[good_statuses])


### PR DESCRIPTION
I had problems with the `since` and `until` argument. `searchTwitter` always returns an empty list. Here is an example:

```
twitteR::searchTwitter("#rstats", since = "2016-01-05", until = "2016-01-05", n = 20)
```

The problem is that `which(datetimes <= as.numeric(as.POSIXct(until, tz="UTC")))` return an empty list. I am not 100% sure but I think the problem is that `since` and `until` are `Date` objects converted to `POSIXct` and then numeric.  I changed the test from numeric representation of time (`POSIXct`) to numeric representation of `Date` objects. Now `twitteR::searchTwitter("#rstats", since = "2016-01-05", until = "2016-01-05", n = 20)` returns 20 results.