### PR TITLE
Fixes #119 parsing of UIDs > 2^53

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -64,7 +64,8 @@ parseUsers <- function(users) {
   }
 
   numUsers <- suppressWarnings(as.numeric(users))
-  uids <- numUsers[!is.na(numUsers)]
+  uids <- c(numUsers[!is.na(numUsers) & as.character(numUsers) == as.character(users)],
+            users[!is.na(numUsers) & as.character(numUsers) != as.character(users)])
   screen.names <- setdiff(users, uids)
 
   return(buildUserList(uids, screen.names))


### PR DESCRIPTION
For integers bigger than 2^53 as.numeric() generally loses precision: http://stackoverflow.com/questions/1848700/biggest-integer-that-can-be-stored-in-a-double
E.g. users <- "9007199254740993"  # 2^53+1
Then !is.na(numUsers) is TRUE but users also appears in setdiff(users, uids), because numUsers != users.